### PR TITLE
ci: Add mypy check for successful builds to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ install:
 script:
   - flake8 .
   - pytest
+after_success:
+  - mypy .


### PR DESCRIPTION
The after_success bit only gets run once a build has passed and it's result doesn't affect the build's status.