### PR TITLE
serialise: Add serialize_model helper func

### DIFF
--- a/parking/shared/util.py
+++ b/parking/shared/util.py
@@ -1,4 +1,6 @@
+import json
 from typing import Union
+import attr
 
 
 def ensure(t):
@@ -15,6 +17,11 @@ def ensure(t):
         else:
             raise TypeError('Expected mapping or {}'.format(t))
     return check
+
+
+def serialize_model(model: object) -> str:
+    '''Handy function to dump an attr object to a JSON encoded string'''
+    return json.dumps(attr.asdict(model))
 
 
 def validate_pos(cls, attribute, value: Union[int, float]) -> None:

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -1,0 +1,14 @@
+import pytest
+from parking.shared.util import serialize_model
+from parking.shared.rest_models import SpaceAvailableMessage
+
+
+def test_serialize_model():
+    json_str = '{"available": 10}'
+    sam = SpaceAvailableMessage(10)
+    assert serialize_model(sam) == json_str
+
+
+def test_serialize_model_raises_error():
+    with pytest.raises(ValueError):
+        serialize_model(None)


### PR DESCRIPTION
This PR means that we won't have to import json and attr when we want to serialise something:

```
import json
import attr

message = LocationUpdateMessage(Location(0.0, 1.0))
json_msg = json.dumps(attr.asdict(message))
```

Becomes:

```
from parking.shared.util import serialize_model

message = LocationUpdateMessage(Location(0.0, 1.0))
json_msg = serialize_model(message)
```