### PR TITLE
Add coverage metrics to the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
   - pip install -r requirements.txt
 script:
   - flake8 .
-  - pytest
+  - coverage run --source=parking -m pytest
 after_success:
   - mypy .
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # parking
+
+[![Build Status](https://travis-ci.com/educationallylimited/parking.svg?branch=master)](https://travis-ci.com/educationallylimited/parking)
+[![Coverage Status](https://coveralls.io/repos/github/educationallylimited/parking/badge.svg?branch=master)](https://coveralls.io/github/educationallylimited/parking?branch=master)
+
 Parking monolith
 
 ## Installing requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ attrs>=18.1.0
 mypy>=0.600
 wheel>=0.31.1
 tornado>=5.0.2
+coveralls
+coverage
+pytest-cov


### PR DESCRIPTION
Adds a coverage step to the Travis build which publishes coverage
to `coveralls`.

This also adds 'shields' for both the Travis build and the coverage
status.