### PR TITLE
Simplify attribute type checking

### DIFF
--- a/parking/shared/rest_models.py
+++ b/parking/shared/rest_models.py
@@ -1,27 +1,27 @@
 import attr
 from parking.shared.location import Location
-from parking.shared.util import ensure, validate_non_neg, validate_pos
+from parking.shared.util import ensure, validate_non_neg, validate_pos, enforce_type
 
 
 @attr.s
 class ParkingLot:
-    capacity: int = attr.ib(validator=[attr.validators.instance_of(int), validate_pos])
-    name: str = attr.ib(validator=attr.validators.instance_of(str))
-    price: float = attr.ib(validator=[attr.validators.instance_of(float), validate_non_neg])
+    capacity: int = attr.ib(validator=[enforce_type, validate_pos])
+    name: str = attr.ib(validator=enforce_type)
+    price: float = attr.ib(converter=float, validator=validate_non_neg)
     location: Location = attr.ib(converter=ensure(Location), validator=attr.validators.instance_of(Location))
-    id: int = attr.ib(validator=attr.validators.instance_of(int), default=0)
+    id: int = attr.ib(validator=enforce_type, default=0)
 
 
 @attr.s
 class ParkingLotCreationResponse:
-    id: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg], default=0)
+    id: int = attr.ib(validator=[enforce_type, validate_non_neg], default=0)
 
 
 @attr.s
 class ParkingLotAvailableMessage:
-    available: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg])
+    available: int = attr.ib(validator=[enforce_type, validate_non_neg])
 
 
 @attr.s
 class ParkingLotPriceMessage:
-    price: float = attr.ib(validator=[attr.validators.instance_of(float), validate_non_neg])
+    price: float = attr.ib(validator=[enforce_type, validate_non_neg])

--- a/parking/shared/util.py
+++ b/parking/shared/util.py
@@ -1,5 +1,4 @@
 import json
-from typing import Union
 import attr
 
 
@@ -24,11 +23,17 @@ def serialize_model(model: object) -> str:
     return json.dumps(attr.asdict(model))
 
 
-def validate_pos(cls, attribute, value: Union[int, float]) -> None:
+def validate_pos(cls, attribute, value: float) -> None:
     if value < 1:
         raise ValueError('{} must be positive'.format(attribute.name))
 
 
-def validate_non_neg(cls, attribute, value: Union[int, float]) -> None:
+def validate_non_neg(cls, attribute, value: float) -> None:
     if value < 0:
         raise ValueError('{} must be non-negative'.format(attribute.name))
+
+
+def enforce_type(cls, attribute, value) -> None:
+    if not isinstance(value, attribute.type):
+        raise TypeError('{} must be of type {}'
+                        .format(attribute.name, str(attribute.type)))

--- a/parking/shared/ws_models.py
+++ b/parking/shared/ws_models.py
@@ -2,7 +2,7 @@ import json
 from enum import IntEnum
 import attr
 from parking.shared.location import Location
-from parking.shared.util import ensure, validate_non_neg
+from parking.shared.util import ensure, validate_non_neg, enforce_type
 from parking.shared.rest_models import ParkingLot
 
 
@@ -31,50 +31,50 @@ def deserialize_ws_message(data: str):
 
 @attr.s
 class LocationUpdateMessage:
-    location: Location = attr.ib(converter=ensure(Location), validator=attr.validators.instance_of(Location))
+    location: Location = attr.ib(converter=ensure(Location))
     _type: int = attr.ib(default=WebSocketMessageType.LOCATION_UPDATE.value, init=False)
 
 
 @attr.s
 class ParkingRequestMessage:
-    location: Location = attr.ib(converter=ensure(Location), validator=attr.validators.instance_of(Location))
+    location: Location = attr.ib(converter=ensure(Location))
     # TODO: Maybe make a preferences class so that we can validate the content
     # of preferences.
-    preferences: dict = attr.ib(validator=attr.validators.instance_of(dict), factory=dict)
+    preferences: dict = attr.ib(validator=enforce_type, factory=dict)
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_REQUEST.value, init=False)
 
 
 @attr.s
 class ParkingAllocationMessage:
     # TODO: Maybe have an error class to validate the error.
-    lot: ParkingLot = attr.ib(converter=ensure(ParkingLot), validator=attr.validators.instance_of(ParkingLot))
-    error: dict = attr.ib(validator=attr.validators.instance_of(dict), factory=dict)
+    lot: ParkingLot = attr.ib(converter=ensure(ParkingLot))
+    error: dict = attr.ib(validator=enforce_type, factory=dict)
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_ALLOCATION.value, init=False)
 
 
 @attr.s
 class ParkingAcceptanceMessage:
-    id: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg])
+    id: int = attr.ib(validator=[enforce_type, validate_non_neg])
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_ACCEPTANCE.value, init=False)
 
 
 @attr.s
 class ParkingRejectionMessage:
-    id: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg])
+    id: int = attr.ib(validator=[enforce_type, validate_non_neg])
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_REJECTION.value, init=False)
 
 
 @attr.s
 class ParkingDeallocationMessage:
-    id: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg])
+    id: int = attr.ib(validator=[enforce_type, validate_non_neg])
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_DEALLOC.value, init=False)
 
 
 @attr.s
 class ParkingCancellationMessage:
     # TODO: Add a reason enum somewhere, with 0 being REASON_UNKNOWN or similar.
-    id: int = attr.ib(validator=[attr.validators.instance_of(int), validate_non_neg])
-    reason: int = attr.ib(validator=attr.validators.instance_of(int), default=0)
+    id: int = attr.ib(validator=[enforce_type, validate_non_neg])
+    reason: int = attr.ib(validator=enforce_type, default=0)
     _type: int = attr.ib(default=WebSocketMessageType.PARKING_CANCEL.value, init=False)
 
 


### PR DESCRIPTION
- Removes some redundant checks (e.g. type checking after conversion)
- Moves some checks to conversions (e.g. checking for float -> convert to float)
- Uses `Attribute.type` for explicit type checks via `utils.enforce_type`